### PR TITLE
feat: add an api for other mods

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,10 +9,15 @@ file(GLOB SOURCES
     src/managers/*.cpp
     src/hooks/*.cpp
     src/events/*.cpp
+    src/api/*.cpp
 	src/*.cpp
 )
 
 add_library(${PROJECT_NAME} SHARED ${SOURCES})
+
+if (PROJECT_IS_TOP_LEVEL)
+  target_compile_definitions(${PROJECT_NAME} PRIVATE FLEYM_JUKEBOX_EXPORTING)
+endif()
 
 if (NOT DEFINED ENV{GEODE_SDK})
     message(FATAL_ERROR "Unable to find Geode SDK! Please define GEODE_SDK environment variable to point to Geode")

--- a/include/jukebox.hpp
+++ b/include/jukebox.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "../src/types/song_info.hpp"
+#include <optional>
+
+#ifdef GEODE_IS_WINDOWS
+    #ifdef FLEYM_JUKEBOX_EXPORTING
+        #define JUKEBOX_DLL __declspec(dllexport)
+    #else
+        #define JUKEBOX_DLL __declspec(dllimport)
+    #endif
+#else
+    #define JUKEBOX_DLL __attribute__((visibility("default")))
+#endif
+
+namespace jukebox {
+    /**
+     * Adds a NONG to the JSON of a songID
+     * 
+     * @param song the song to add
+     * @param songID the id of the song
+    */
+    JUKEBOX_DLL void addNong(SongInfo const& song, int songID);
+
+    /**
+     * Sets the active song of a songID
+     * 
+     * @param song the song to set as active
+     * @param songID the id of the song
+    */
+    JUKEBOX_DLL void setActiveSong(SongInfo const& song, int songID);
+}

--- a/mod.json
+++ b/mod.json
@@ -24,6 +24,12 @@
 			"default": false
 		}
 	},
+	"api": {
+		"include": [
+			"include/*.hpp",
+			"src/types/song_info.hpp"
+		]
+	},
 	"resources": {
 		"sprites": [
 			"resources/*.png"

--- a/src/api/jukebox.cpp
+++ b/src/api/jukebox.cpp
@@ -1,0 +1,22 @@
+#include "../../include/jukebox.hpp"
+#include "../managers/nong_manager.hpp"
+
+namespace fs = std::filesystem;
+
+namespace jukebox {
+  JUKEBOX_DLL void addNong(SongInfo const& song, int songID) {
+    NongManager::get()->addNong(song, songID);
+  }
+
+  JUKEBOX_DLL void setActiveSong(SongInfo const& song, int songID) {
+    NongData data = NongManager::get()->getNongs(songID).value();
+
+    if (!fs::exists(song.path)) {
+        return;
+    }
+
+    data.active = song.path;
+
+    NongManager::get()->saveNongs(data, songID);
+  }
+}


### PR DESCRIPTION
Adds an api similar to GMD-API's.
The purpose of this API is to allow other mods to set/activate/get NONG songs from Jukebox.
For now only adding songs and setting them as active is available from the api.
At the moment, the only functionality this API offers is adding NONG songs and activating a song. More functions can be added later.

- There is an issue with `setActiveSong` where is would not update `CustomSongWidget`'s song info before starting to play a level(Reopening that screen updates it). To fix this `setActiveSong` needs the instance of `CustomSongWidget`, but I have no idea how to get it without introducing a global variable.

- Only tested on Windows(wine).

## Example:

After adding `fleym.nongd` as a dependency in `mod.json`, the mod will be able to do this:
```cpp
#include <fleym.nongd/include/jukebox.hpp>

...

SongInfo song = {
    .path = "Z:\\home\\user\\Downloads\\music.mp3",
    .songName = "my song name",
    .authorName = "artist",
    .songUrl = "local",
};
jukebox::addNong(song, 945695);
jukebox::setActiveSong(song, 945695);
```