### PR TITLE
feat(api): Add getActiveSong, deleteNong, and getDefaultSong

### DIFF
--- a/include/jukebox.hpp
+++ b/include/jukebox.hpp
@@ -27,6 +27,29 @@ namespace jukebox {
      * 
      * @param song the song to set as active
      * @param songID the id of the song
+     * @param customSongWidget optional custom song widget to update
     */
-    JUKEBOX_DLL void setActiveSong(SongInfo const& song, int songID);
+    JUKEBOX_DLL void setActiveNong(SongInfo const& song, int songID, const std::optional<geode::Ref<CustomSongWidget>>& customSongWidget);
+
+    /**
+     * Gets the active song of a songID
+     * 
+     * @param songID the id of the song
+    */
+    JUKEBOX_DLL std::optional<SongInfo> getActiveNong(int songID);
+
+    /**
+     * Deletes a NONG from the JSON of a songID
+     * 
+     * @param song the song to delete
+     * @param songID the id of the replaced song
+    */
+    JUKEBOX_DLL void deleteNong(SongInfo const& song, int songID);
+
+    /**
+     * Sets the song of the songID as the default song provided by GD
+     * 
+     * @param songID the id of the song
+    */
+    JUKEBOX_DLL std::optional<SongInfo> getDefaultNong(int songID);
 }

--- a/src/api/jukebox.cpp
+++ b/src/api/jukebox.cpp
@@ -8,7 +8,7 @@ namespace jukebox {
     NongManager::get()->addNong(song, songID);
   }
 
-  JUKEBOX_DLL void setActiveSong(SongInfo const& song, int songID) {
+  JUKEBOX_DLL void setActiveNong(SongInfo const& song, int songID, const std::optional<Ref<CustomSongWidget>>& customSongWidget) {
     NongData data = NongManager::get()->getNongs(songID).value();
 
     if (!fs::exists(song.path)) {
@@ -18,5 +18,28 @@ namespace jukebox {
     data.active = song.path;
 
     NongManager::get()->saveNongs(data, songID);
+
+    if (customSongWidget.has_value()) {
+      const Ref<CustomSongWidget> widget = customSongWidget.value();
+
+      widget->m_songInfoObject->m_artistName = song.authorName;
+      widget->m_songInfoObject->m_songName = song.songName;
+      if (song.songUrl != "local") {
+          widget->m_songInfoObject->m_songUrl = song.songUrl;
+      }
+      widget->updateSongObject(widget->m_songInfoObject);
+    }
+  }
+
+  JUKEBOX_DLL std::optional<SongInfo> getActiveNong(int songID) {
+    return NongManager::get()->getActiveNong(songID);
+  }
+
+  JUKEBOX_DLL void deleteNong(SongInfo const& song, int songID) {
+    NongManager::get()->deleteNong(song, songID);
+  }
+
+  JUKEBOX_DLL std::optional<SongInfo> getDefaultNong(int songID) {
+    return NongManager::get()->getDefaultNong(songID);
   }
 }


### PR DESCRIPTION
Adds 3 new api methods:
- `getActiveNong`
- `deleteNong`
- `getDefaultNong`

And a new parameter `customSongWidget` to `setActiveNong`

~~Don't know why I named some of the methods with "song" and some with "nong". If you want to regulate it tell me which one and I'll rename the methods.~~ Renamed to Nong