### PR TITLE
feat: Add start offset to nongs

### DIFF
--- a/src/hooks/fmod_audio_engine.cpp
+++ b/src/hooks/fmod_audio_engine.cpp
@@ -1,0 +1,27 @@
+#include <Geode/binding/FMODAudioEngine.hpp>
+#include <Geode/modify/FMODAudioEngine.hpp>
+
+#include "../managers/nong_manager.hpp"
+
+using namespace jukebox;
+
+class $modify(FMODAudioEngine) {
+    void queueStartMusic(gd::string audioFilename, float p1, float p2, float p3, bool p4,
+                         int ms, int p6, int p7, int p8, int p9, bool p10,
+                         int p11, bool p12) {
+        if (NongManager::get()->m_currentlyPreparingNong) {
+          int additionalOffset = NongManager::get()->m_currentlyPreparingNong.value().startOffset;
+          FMODAudioEngine::queueStartMusic(audioFilename, p1, p2, p3, p4, ms+additionalOffset, p6, p7, p8, p9, p10, p11, p12);
+        } else {
+          FMODAudioEngine::queueStartMusic(audioFilename, p1, p2, p3, p4, ms, p6, p7, p8, p9, p10, p11, p12);
+        }
+    }
+    void setMusicTimeMS(unsigned int ms, bool p1, int channel) {
+        if (NongManager::get()->m_currentlyPreparingNong) {
+            int additionalOffset = NongManager::get()->m_currentlyPreparingNong.value().startOffset;
+            FMODAudioEngine::setMusicTimeMS(ms+additionalOffset, p1, channel);
+        } else {
+            FMODAudioEngine::setMusicTimeMS(ms, p1, channel);
+        }
+    }
+};

--- a/src/hooks/gj_game_level.cpp
+++ b/src/hooks/gj_game_level.cpp
@@ -12,6 +12,7 @@ using namespace geode::prelude;
 
 class $modify(GJGameLevel) {
     gd::string getAudioFileName() {
+        jukebox::NongManager::get()->m_currentlyPreparingNong = std::nullopt;
         if (m_songID != 0) {
             return GJGameLevel::getAudioFileName();
         }
@@ -24,6 +25,7 @@ class $modify(GJGameLevel) {
         if (!std::filesystem::exists(value.path)) {
             return GJGameLevel::getAudioFileName();
         }
+        jukebox::NongManager::get()->m_currentlyPreparingNong = value;
         #ifdef GEODE_IS_WINDOWS
         return geode::utils::string::wideToUtf8(value.path.c_str());
         #else

--- a/src/hooks/music_download_manager.cpp
+++ b/src/hooks/music_download_manager.cpp
@@ -10,6 +10,7 @@ using namespace jukebox;
 
 class $modify(MusicDownloadManager) {
 	gd::string pathForSong(int id) {
+        NongManager::get()->m_currentlyPreparingNong = std::nullopt;
         auto active = NongManager::get()->getActiveNong(id);
         if (!active.has_value()) {
             return MusicDownloadManager::pathForSong(id);
@@ -18,6 +19,7 @@ class $modify(MusicDownloadManager) {
 		if (!fs::exists(value.path)) {
             return MusicDownloadManager::pathForSong(id);
 		}
+        NongManager::get()->m_currentlyPreparingNong = active;
         #ifdef GEODE_IS_WINDOWS
         return geode::utils::string::wideToUtf8(value.path.c_str());
         #else

--- a/src/managers/nong_manager.cpp
+++ b/src/managers/nong_manager.cpp
@@ -256,6 +256,7 @@ void NongManager::createUnknownDefault(int songID) {
     defaultSong.songName = "Unknown";
     defaultSong.path = songPath;
     defaultSong.songUrl = "";
+    defaultSong.startOffset = 0;
     data.active = songPath;
     data.defaultPath = songPath;
     data.songs.push_back(defaultSong);

--- a/src/managers/nong_manager.hpp
+++ b/src/managers/nong_manager.hpp
@@ -37,6 +37,7 @@ protected:
     void backupCurrentJSON();
 public:
     using MultiAssetSizeTask = Task<std::string>;
+    std::optional<SongInfo> m_currentlyPreparingNong;
 
     bool initialized() { return m_initialized; }
 

--- a/src/types/song_info.hpp
+++ b/src/types/song_info.hpp
@@ -19,6 +19,7 @@ struct SongInfo {
     std::string authorName;
     std::string songUrl;
     std::string levelName;
+    int startOffset = 0;
 };
 
 struct NongData {
@@ -128,7 +129,8 @@ struct matjson::Serialize<jukebox::NongData> {
                 .songName = jsonSong["songName"].as_string(),
                 .authorName = jsonSong["authorName"].as_string(),
                 .songUrl = jsonSong["songUrl"].as_string(),
-                .levelName = levelName
+                .levelName = levelName,
+                .startOffset = jsonSong.try_get<int>("startOffset").value_or(0)
             };
             songs.push_back(song);
         }
@@ -160,6 +162,7 @@ struct matjson::Serialize<jukebox::NongData> {
             obj["authorName"] = song.authorName;
             obj["songUrl"] = song.songUrl;
             obj["levelName"] = song.levelName;
+            obj["startOffset"] = song.startOffset;
 
             array.push_back(obj);
         }

--- a/src/ui/nong_add_popup.cpp
+++ b/src/ui/nong_add_popup.cpp
@@ -211,6 +211,14 @@ void NongAddPopup::createInputs() {
     levelNameInput->getInputNode()->setLabelPlaceholderScale(0.7f);
     m_levelNameInput = levelNameInput;
 
+    auto startOffsetInput = TextInput::create(250.f, "Start offset", "bigFont.fnt");
+    startOffsetInput->setID("start-offset-input");
+    startOffsetInput->setCommonFilter(CommonFilter::Int);
+    startOffsetInput->getInputNode()->setLabelPlaceholderColor(ccColor3B {108, 153, 216});
+    startOffsetInput->getInputNode()->setMaxLabelScale(0.7f);
+    startOffsetInput->getInputNode()->setLabelPlaceholderScale(0.7f);
+    m_startOffsetInput = startOffsetInput;
+
     uint32_t inputs = 3;
     uint32_t gaps = 2;
     float inputHeight = songInput->getContentSize().height;
@@ -218,6 +226,7 @@ void NongAddPopup::createInputs() {
     inputParent->addChild(songInput);
     inputParent->addChild(artistInput);
     inputParent->addChild(levelNameInput);
+    inputParent->addChild(startOffsetInput);
     auto layout = ColumnLayout::create();
     layout->setAxisReverse(true);
     inputParent->setContentSize({ 250.f, inputs * inputHeight + gaps * layout->getGap()});
@@ -231,6 +240,7 @@ void NongAddPopup::addSong(CCObject* target) {
     auto artistName = std::string(m_artistNameInput->getString());
     auto songName = std::string(m_songNameInput->getString());
     std::string levelName = m_levelNameInput->getString();
+    auto startOffsetStr = m_startOffsetInput->getString();
     #ifdef GEODE_IS_WINDOWS
     if (wcslen(m_songPath.c_str()) == 0) {
     #else
@@ -266,6 +276,12 @@ void NongAddPopup::addSong(CCObject* target) {
         return;
     }
 
+    int startOffset = 0;
+
+    if (startOffsetStr != "") {
+        startOffset = std::stoi(startOffsetStr);
+    }
+
     auto unique = jukebox::random_string(16);
     auto destination = Mod::get()->getSaveDir() / "nongs";
     if (!fs::exists(destination)) {
@@ -292,7 +308,8 @@ void NongAddPopup::addSong(CCObject* target) {
         .songName = songName,
         .authorName = artistName,
         .songUrl = "local",
-        .levelName = levelName
+        .levelName = levelName,
+        .startOffset = startOffset,
     };
 
     m_parentPopup->addSong(song);

--- a/src/ui/nong_add_popup.hpp
+++ b/src/ui/nong_add_popup.hpp
@@ -27,6 +27,7 @@ protected:
     TextInput* m_songNameInput;
     TextInput* m_artistNameInput;
     TextInput* m_levelNameInput;
+    TextInput* m_startOffsetInput;
 
     fs::path m_songPath;
     CCNode* m_selectedContainer;


### PR DESCRIPTION
A lot of the time songs don't sync well when adding them. either because the new song's mp3 has an intro, the level put a weird start offset(like slaughterhouse), or any other reason.

For example with Slaughterhouse, the song starts with an offset of 35 seconds. That makes it hard to [replace it with remixes](https://github.com/FlafyDev/auto-nong-indexes/issues/38) and people have to create MP3s [like this](https://www.youtube.com/watch?v=VZXeoUPPFOY) to get around this.

I see this a lot in Auto Nong. Because most of the audio files are downloaded directly from Youtube(which a lot of the times has an intro for songs), the only preprocessing that we can make on the mp3 is on device, and that could get very complicated and requires heavy dependencies.

I also believe this feature will make it a lot more convenient to sync custom songs in general.

![image](https://github.com/Fleeym/jukebox/assets/44374434/b3c9195e-723c-422f-803f-63a2961a6f28)

