### PR TITLE
fix: Allow selecting the default song without the file downloaded

### DIFF
--- a/src/ui/nong_dropdown_layer.cpp
+++ b/src/ui/nong_dropdown_layer.cpp
@@ -254,7 +254,9 @@ void NongDropdownLayer::setActiveSong(SongInfo const& song) {
     }
     int id = m_currentSongID.value();
     auto songs = m_data[id];
-    if (!fs::exists(song.path)) {
+    auto defaultNong = NongManager::get()->getDefaultNong(id);
+    auto isDefault = defaultNong.has_value() && defaultNong->path == song.path;
+    if (!isDefault && !fs::exists(song.path)) {
         FLAlertLayer::create("Failed", "Failed to set song: file not found", "Ok")->show();
         return;
     }


### PR DESCRIPTION
Currently if you switch to a nong in jukebox without downloading the default song you can't switch to the default song. It prompts with a file not found. This fixes that.