### PR TITLE
fix: Delete song's audio file

### DIFF
--- a/include/jukebox.hpp
+++ b/include/jukebox.hpp
@@ -43,8 +43,9 @@ namespace jukebox {
      * 
      * @param song the song to delete
      * @param songID the id of the replaced song
+     * @param deleteFile whether to delete the corresponding audio file created by Jukebox
     */
-    JUKEBOX_DLL void deleteNong(SongInfo const& song, int songID);
+    JUKEBOX_DLL void deleteNong(SongInfo const& song, int songID, bool deleteFile = true);
 
     /**
      * Sets the song of the songID as the default song provided by GD

--- a/src/api/jukebox.cpp
+++ b/src/api/jukebox.cpp
@@ -35,8 +35,8 @@ namespace jukebox {
     return NongManager::get()->getActiveNong(songID);
   }
 
-  JUKEBOX_DLL void deleteNong(SongInfo const& song, int songID) {
-    NongManager::get()->deleteNong(song, songID);
+  JUKEBOX_DLL void deleteNong(SongInfo const& song, int songID, bool deleteFile) {
+    NongManager::get()->deleteNong(song, songID, deleteFile);
   }
 
   JUKEBOX_DLL std::optional<SongInfo> getDefaultNong(int songID) {

--- a/src/managers/nong_manager.cpp
+++ b/src/managers/nong_manager.cpp
@@ -193,7 +193,7 @@ void NongManager::deleteAll(int songID) {
     this->saveNongs(newData, songID);
 }
 
-void NongManager::deleteNong(SongInfo const& song, int songID) {
+void NongManager::deleteNong(SongInfo const& song, int songID, bool deleteFile) {
     std::vector<SongInfo> newSongs;
     auto result = this->getNongs(songID);
     if(!result.has_value()) {
@@ -205,7 +205,7 @@ void NongManager::deleteNong(SongInfo const& song, int songID) {
             if (song.path == existingData.active) {
                 existingData.active = existingData.defaultPath;
             }
-            if (song.songUrl != "local" && existingData.defaultPath != song.path && fs::exists(song.path)) {
+            if (deleteFile && existingData.defaultPath != song.path && fs::exists(song.path)) {
                 std::error_code ec;
                 fs::remove(song.path, ec);
                 if (ec) {

--- a/src/managers/nong_manager.hpp
+++ b/src/managers/nong_manager.hpp
@@ -71,8 +71,9 @@ public:
      * 
      * @param song the song to remove
      * @param songID the id of the song
+     * @param deleteFile whether to delete the corresponding audio file created by Jukebox
     */
-    void deleteNong(SongInfo const& song, int songID);
+    void deleteNong(SongInfo const& song, int songID, bool deleteFile = true);
 
     /**
      * Fetches all NONG data for a certain songID


### PR DESCRIPTION
When deleting a song in Jukebox it doesn't delete the audio file it created. This fixes that and adds an optional parameter in Jukebox and in the API to not delete the file.