### PR TITLE
fix: Crash on editor settings

### DIFF
--- a/src/hooks/custom_song_widget.cpp
+++ b/src/hooks/custom_song_widget.cpp
@@ -121,6 +121,7 @@ class $modify(JBSongWidget, CustomSongWidget) {
 
     void setupJBSW() {
         SongInfoObject* obj = m_songInfoObject;
+        if (obj == nullptr) return;
         if (!m_fields->fetchedAssetInfo && m_songs.size() != 0) {
             this->getMultiAssetSongInfo();
         }


### PR DESCRIPTION
When entering the settings in the level editor the game crashes if the level's song is a RobTop song.

The PR "fixes" this by just returning when songInfoObject is nullptr. That means the name of the song will not be clickable in the first level editor settings menu. This is the same behavior Jukebox had previously but it got removed somehow.

fixes: #45 