### PR TITLE
Editing user added local songs causes the local song's file to be deleted

### DIFF
--- a/src/ui/nong_add_popup.cpp
+++ b/src/ui/nong_add_popup.cpp
@@ -679,24 +679,24 @@ geode::Result<> NongAddPopup::addLocalSong(
     }
     destination /= unique;
 
-    if (std::filesystem::exists(destination, error_code)) {
-        std::filesystem::remove(destination, error_code);
+    if (destination.compare(songPath) != 0) {
+        bool result = std::filesystem::copy_file(
+            songPath,
+            destination,
+            std::filesystem::copy_options::overwrite_existing,
+            error_code);
+        if (error_code) {
+            return Err(fmt::format(
+                "Failed to save song. Please try again! Error category: {}, "
+                "message: {}",
+                error_code.category().name(),
+                error_code.category().message(error_code.value())));
+        }
+        if (!result) {
+            return Err(
+                "Failed to copy song to Jukebox's songs folder. Please try again.");
+        }
     }
-
-    bool result = std::filesystem::copy_file(songPath, destination, error_code);
-    if (error_code) {
-        return Err(fmt::format(
-            "Failed to save song. Please try again! Error category: {}, "
-            "message: {}",
-            error_code.category().name(),
-            error_code.category().message(error_code.value())));
-    }
-    if (!result) {
-        return Err(
-            "Failed to copy song to Jukebox's songs folder. Please try again.");
-    }
-
-    std::string error = "";
 
     LocalSong song = LocalSong{
         SongMetadata{m_songID, id, songName, artistName, levelName, offset},


### PR DESCRIPTION
in `NongAddPopup::addLocalSong` the code attempts to copy `songPath` into `destination`, so it fails when they are pointing to the same file. They are pointing to the same file when editing a local song.

The code fails because:
1. It attempts to delete destination and copy songPath into it. But when they are the same file then songPath is also deleted.
2. The copy function doesn't allow both inputs to point to the same file

The fix is checking with `std::filesystem::path::compare` if they are the same path. If it is the same path, then skip copying.

Also, I replaced the "`exists` then `remove`" with the copy option: `std::filesystem::copy_options::overwrite_existing`.

And removed the `std::string error = "";` line. I think it's useless