### PR TITLE
Fix pin rays being at the wrong location

### DIFF
--- a/jukebox/jukebox/hooks/custom_song_widget.cpp
+++ b/jukebox/jukebox/hooks/custom_song_widget.cpp
@@ -527,7 +527,7 @@ class $modify(JBSongWidget, CustomSongWidget) {
             m_fields->sprRays = sprRays;
             m_fields->btnDisc = btnDisc;
 
-            m_fields->pinMenu->addChildAtPosition(sprRays, Anchor::Center);
+            btnDisc->addChildAtPosition(sprRays, Anchor::Center);
 
             static constexpr float rotationDuration = 80.0f;
             CCRepeatForever* rotateAction = CCRepeatForever::create(CCRotateBy::create(rotationDuration, 360));


### PR DESCRIPTION
Fixed pin rays being being at a random location at the screen instead of below the disc