### PR TITLE
Fix NONGs only playing one song

### DIFF
--- a/jukebox/jukebox/managers/index_manager.cpp
+++ b/jukebox/jukebox/managers/index_manager.cpp
@@ -482,7 +482,7 @@ void IndexManager::onDownloadFinish(std::variant<IndexSongMetadata*, Song*>&& so
 }
 
 void IndexManager::registerIndexNongs(Nongs* destination) {
-    if (m_nongsForId.contains(!destination->songID())) {
+    if (m_nongsForId.contains(destination->songID())) {
         return;
     }
 


### PR DESCRIPTION
This is pretty much just a quick little fix to the issue I made, or at least the one Copilot suggested (don’t blame me, i don’t know c++).

in index_manager.cpp, at line ~485 there is a ! where there shouldn’t be, which breaks custom indexes at least in my experience. That’s all i did :]