### PR TITLE
fix: remove all references to Tasks

### DIFF
--- a/jukebox/jukebox/managers/index_manager.cpp
+++ b/jukebox/jukebox/managers/index_manager.cpp
@@ -305,16 +305,6 @@ Result<> IndexManager::downloadSong(int gdSongID, const std::string_view uniqueI
         }
 
         return Err("YouTube song downloads will be enabled in a future release!");
-
-        /*Result<DownloadSongTask> t = song->startDownload();*/
-        /*if (t.isErr()) {*/
-        /*    return Err("Failed to start download: {}", t.error());*/
-        /*}*/
-        /**/
-        /*task = t.unwrap();*/
-        /*found = true;*/
-        /*local = song.get();*/
-        /*break;*/
     }
 
     for (const std::unique_ptr<HostedSong>& song : nongs->hosted()) {

--- a/jukebox/jukebox/managers/nong_manager.cpp
+++ b/jukebox/jukebox/managers/nong_manager.cpp
@@ -16,8 +16,8 @@
 #include <Geode/binding/SongInfoObject.hpp>
 #include <Geode/loader/Log.hpp>
 #include <Geode/utils/file.hpp>
-#include <asp/iter.hpp>
 #include <asp/fs/fs.hpp>
+#include <asp/iter.hpp>
 #include <matjson.hpp>
 
 #include <jukebox/compat/compat.hpp>
@@ -209,7 +209,8 @@ bool NongManager::init() {
             auto renameRes = asp::fs::rename(entry.path(), path / fmt::format("{}.bak", entry.path().filename()));
             if (renameRes.isErr()) {
                 auto err = renameRes.unwrapErr();
-                log::error("Failed to rename file {}: Code: {}, message: {}", entry.path(), err.getCode(), err.message());
+                log::error("Failed to rename file {}: Code: {}, message: {}", entry.path(), err.getCode(),
+                           err.message());
             }
             continue;
         }

--- a/jukebox/jukebox/managers/nong_manager.hpp
+++ b/jukebox/jukebox/managers/nong_manager.hpp
@@ -1,16 +1,15 @@
 #pragma once
 
-#include <filesystem>
 #include <asp/fs.hpp>
+#include <filesystem>
 #include <memory>
 #include <optional>
 #include <string_view>
 
 #include <Geode/Result.hpp>
 #include <Geode/loader/Log.hpp>
-#include <Geode/utils/file.hpp>
 #include <Geode/loader/Mod.hpp>
-#include <Geode/utils/Task.hpp>
+#include <Geode/utils/file.hpp>
 
 #include <jukebox/nong/nong.hpp>
 
@@ -46,7 +45,6 @@ public:
     NongManager& operator=(const NongManager&) = delete;
     NongManager& operator=(NongManager&&) = delete;
 
-    using MultiAssetSizeTask = geode::Task<std::string>;
     std::optional<Nongs*> m_currentlyPreparingNong = std::nullopt;
 
     bool init();
@@ -145,8 +143,7 @@ public:
      * @param resourcesDir CCFileUtils::get()->getWritablePath2() / "Resources"
      * @param songDir CCFileUtils::get()->getWritablePath()
      */
-    arc::Future<std::string> getMultiAssetSizes(std::string songs, std::string sfx,
-                                                std::filesystem::path resourcesDir,
+    arc::Future<std::string> getMultiAssetSizes(std::string songs, std::string sfx, std::filesystem::path resourcesDir,
                                                 std::filesystem::path songDir);
 
     /**

--- a/jukebox/jukebox/nong/nong.hpp
+++ b/jukebox/jukebox/nong/nong.hpp
@@ -9,7 +9,6 @@
 #include <fmt/core.h>
 #include <Geode/Result.hpp>
 #include <Geode/binding/SongInfoObject.hpp>
-#include <Geode/utils/Task.hpp>
 #include <Geode/utils/general.hpp>
 #include <arc/future/Future.hpp>
 #include <matjson.hpp>

--- a/jukebox/jukebox/ui/nong_add_popup.hpp
+++ b/jukebox/jukebox/ui/nong_add_popup.hpp
@@ -14,7 +14,6 @@
 #include <Geode/loader/Event.hpp>
 #include <Geode/ui/Popup.hpp>
 #include <Geode/ui/TextInput.hpp>
-#include <Geode/utils/Task.hpp>
 
 #include <jukebox/nong/nong.hpp>
 #include <jukebox/ui/nong_dropdown_layer.hpp>
@@ -71,8 +70,6 @@ protected:
     CCMenuItemSpriteExtra* m_publishSongButton = nullptr;
 
     SongType m_songType = SongType::LOCAL;
-
-    // geode::EventListener<geode::Task<geode::Result<std::filesystem::path>>> m_pickListener;
 
     std::optional<Song*> m_replacedNong;
 


### PR DESCRIPTION
Geode v6 will remove tasks completely, this just removes some useless references to them.