### PR TITLE
feat: store song filename in saved JSON

### DIFF
--- a/jukebox/jukebox/nong/nong_serialize.hpp
+++ b/jukebox/jukebox/nong/nong_serialize.hpp
@@ -10,12 +10,12 @@
 #include <Geode/loader/Log.hpp>
 #include <Geode/utils/file.hpp>  // IWYU pragma: keep
 
+#include <jukebox/managers/nong_manager.hpp>
 #include <jukebox/nong/nong.hpp>
 
 template <>
 struct matjson::Serialize<jukebox::SongMetadata> {
-    static geode::Result<jukebox::SongMetadata> fromJson(
-        const matjson::Value& value, int songID) {
+    static geode::Result<jukebox::SongMetadata> fromJson(const matjson::Value& value, int songID) {
         if (!value["name"].isString()) {
             return geode::Err("Invalid JSON key name");
         }
@@ -27,37 +27,34 @@ struct matjson::Serialize<jukebox::SongMetadata> {
         }
 
         return geode::Ok(jukebox::SongMetadata{
-            songID, value["unique_id"].asString().unwrap(),
-            value["name"].asString().unwrap(),
+            songID, value["unique_id"].asString().unwrap(), value["name"].asString().unwrap(),
             value["artist"].asString().unwrap(),
-            value["level"]
-                .asString()
-                .map([](auto i) { return std::optional(i); })
-                .unwrapOr(std::nullopt),
+            value["level"].asString().map([](auto i) { return std::optional(i); }).unwrapOr(std::nullopt),
             static_cast<int>(value["offset"].asInt().unwrapOr(0))});
     }
 };
 
 template <>
 struct matjson::Serialize<jukebox::LocalSong> {
-    static geode::Result<jukebox::LocalSong> fromJson(
-        const matjson::Value& value, int songID) {
+    static geode::Result<jukebox::LocalSong> fromJson(const matjson::Value& value, int songID) {
         GEODE_UNWRAP_INTO(
             jukebox::SongMetadata metadata,
-            matjson::Serialize<jukebox::SongMetadata>::fromJson(value, songID)
-                .mapErr([value](std::string err) {
-                    return fmt::format("Local Song {} is invalid. Reason: {}",
-                                       value.dump(matjson::NO_INDENTATION),
-                                       err);
-                }));
+            matjson::Serialize<jukebox::SongMetadata>::fromJson(value, songID).mapErr([value](std::string err) {
+                return fmt::format("Local Song {} is invalid. Reason: {}", value.dump(matjson::NO_INDENTATION), err);
+            }));
 
-        if (!value["path"].isString()) {
-            return geode::Err("Local Song {} is invalid. Reason: invalid path",
-                              value.dump(matjson::NO_INDENTATION));
+        if (value["filename"].isString()) {
+            const std::string filename = value["filename"].asString().unwrap();  // if this crashes I blame mat
+            const std::filesystem::path path = jukebox::NongManager::get().baseNongsPath() / filename;
+
+            return geode::Ok(jukebox::LocalSong{std::move(metadata), path});
         }
 
-        GEODE_UNWRAP_INTO(std::filesystem::path path,
-                          value["path"].as<std::filesystem::path>());
+        if (!value["path"].isString()) {
+            return geode::Err("Local Song {} is invalid. Reason: invalid path", value.dump(matjson::NO_INDENTATION));
+        }
+
+        GEODE_UNWRAP_INTO(std::filesystem::path path, value["path"].as<std::filesystem::path>());
 
         return geode::Ok(jukebox::LocalSong{std::move(metadata), path});
     }
@@ -67,6 +64,7 @@ struct matjson::Serialize<jukebox::LocalSong> {
             {"name", value.metadata()->name},
             {"unique_id", value.metadata()->uniqueID},
             {"artist", value.metadata()->artist},
+            {"filename", value.path()->filename()},
             {"path", value.path().value()},
             {"offset", value.metadata()->startOffset},
         });
@@ -79,49 +77,36 @@ struct matjson::Serialize<jukebox::LocalSong> {
 
 template <>
 struct matjson::Serialize<jukebox::YTSong> {
-    static geode::Result<jukebox::YTSong> fromJson(const matjson::Value& value,
-                                                   int songID) {
+    static geode::Result<jukebox::YTSong> fromJson(const matjson::Value& value, int songID) {
         GEODE_UNWRAP_INTO(
             jukebox::SongMetadata metadata,
-            matjson::Serialize<jukebox::SongMetadata>::fromJson(value, songID)
-                .mapErr([value](std::string err) {
-                    return fmt::format("YouTube song {} is invalid. Reason: {}",
-                                       value.dump(matjson::NO_INDENTATION),
-                                       err);
-                }));
+            matjson::Serialize<jukebox::SongMetadata>::fromJson(value, songID).mapErr([value](std::string err) {
+                return fmt::format("YouTube song {} is invalid. Reason: {}", value.dump(matjson::NO_INDENTATION), err);
+            }));
 
         if (!value["path"].isString()) {
-            return geode::Err(
-                "YouTube song {} is invalid. Reason: invalid path",
-                value.dump(matjson::NO_INDENTATION));
+            return geode::Err("YouTube song {} is invalid. Reason: invalid path", value.dump(matjson::NO_INDENTATION));
         }
 
         if (!value["youtube_id"].isString()) {
-            return geode::Err(
-                "YouTube song {} is invalid. Reason: invalid youtube ID",
-                value.dump(matjson::NO_INDENTATION));
+            return geode::Err("YouTube song {} is invalid. Reason: invalid youtube ID",
+                              value.dump(matjson::NO_INDENTATION));
         }
 
-        GEODE_UNWRAP_INTO(std::filesystem::path path,
-                          value["path"].as<std::filesystem::path>());
+        GEODE_UNWRAP_INTO(std::filesystem::path path, value["path"].as<std::filesystem::path>());
 
         return geode::Ok(jukebox::YTSong{
             std::move(metadata), value["youtube_id"].asString().unwrap(),
-            value["index_id"]
-                .asString()
-                .map([](auto i) { return std::optional(i); })
-                .unwrapOr(std::nullopt),
-            path});
+            value["index_id"].asString().map([](auto i) { return std::optional(i); }).unwrapOr(std::nullopt), path});
     }
 
     static matjson::Value toJson(const jukebox::YTSong& value) {
-        matjson::Value ret =
-            matjson::makeObject({{"name", value.metadata()->name},
-                                 {"unique_id", value.metadata()->uniqueID},
-                                 {"artist", value.metadata()->artist},
-                                 {"path", value.path().value()},
-                                 {"offset", value.metadata()->startOffset},
-                                 {"youtube_id", value.youtubeID()}});
+        matjson::Value ret = matjson::makeObject({{"name", value.metadata()->name},
+                                                  {"unique_id", value.metadata()->uniqueID},
+                                                  {"artist", value.metadata()->artist},
+                                                  {"path", value.path().value()},
+                                                  {"offset", value.metadata()->startOffset},
+                                                  {"youtube_id", value.youtubeID()}});
         if (value.indexID().has_value()) {
             ret["index_id"] = value.indexID().value();
         }
@@ -135,47 +120,47 @@ struct matjson::Serialize<jukebox::YTSong> {
 
 template <>
 struct matjson::Serialize<jukebox::HostedSong> {
-    static geode::Result<jukebox::HostedSong> fromJson(
-        const matjson::Value& value, int songID) {
+    static geode::Result<jukebox::HostedSong> fromJson(const matjson::Value& value, int songID) {
         GEODE_UNWRAP_INTO(
             jukebox::SongMetadata metadata,
-            matjson::Serialize<jukebox::SongMetadata>::fromJson(value, songID)
-                .mapErr([value](std::string err) {
-                    return fmt::format("Hosted song {} is invalid. Reason: {}",
-                                       value.dump(matjson::NO_INDENTATION),
-                                       err);
-                }));
-
-        if (!value["path"].isString()) {
-            return geode::Err("Hosted song {} is invalid. Reason: invalid path",
-                              value.dump(matjson::NO_INDENTATION));
-        }
+            matjson::Serialize<jukebox::SongMetadata>::fromJson(value, songID).mapErr([value](std::string err) {
+                return fmt::format("Hosted song {} is invalid. Reason: {}", value.dump(matjson::NO_INDENTATION), err);
+            }));
 
         if (!value["url"].isString()) {
-            return geode::Err("Hosted song {} is invalid. Reason: invalid url",
-                              value.dump(matjson::NO_INDENTATION));
+            return geode::Err("Hosted song {} is invalid. Reason: invalid url", value.dump(matjson::NO_INDENTATION));
         }
 
-        GEODE_UNWRAP_INTO(std::filesystem::path path,
-                          value["path"].as<std::filesystem::path>());
+        const std::string url = value["url"].asString().unwrap();
+        const std::optional<std::string> indexId =
+            value["index_id"].asString().map([](auto i) { return std::optional(i); }).unwrapOr(std::nullopt);
+
+        if (value["filename"].isString()) {
+            const std::string filename = value["filename"].asString().unwrap();  // if this crashes I blame mat
+            const std::filesystem::path path = jukebox::NongManager::get().baseNongsPath() / filename;
+
+            return geode::Ok(jukebox::HostedSong{std::move(metadata), std::move(url), indexId, path});
+        }
+
+        if (!value["path"].isString()) {
+            return geode::Err("Hosted song {} is invalid. Reason: invalid path", value.dump(matjson::NO_INDENTATION));
+        }
+
+        GEODE_UNWRAP_INTO(std::filesystem::path path, value["path"].as<std::filesystem::path>());
 
         return geode::Ok(jukebox::HostedSong{
             std::move(metadata), value["url"].asString().unwrap(),
-            value["index_id"]
-                .asString()
-                .map([](auto i) { return std::optional(i); })
-                .unwrapOr(std::nullopt),
-            path});
+            value["index_id"].asString().map([](auto i) { return std::optional(i); }).unwrapOr(std::nullopt), path});
     }
 
     static matjson::Value toJson(const jukebox::HostedSong& value) {
-        matjson::Value ret =
-            matjson::makeObject({{"name", value.metadata()->name},
-                                 {"unique_id", value.metadata()->uniqueID},
-                                 {"artist", value.metadata()->artist},
-                                 {"path", value.path().value()},
-                                 {"offset", value.metadata()->startOffset},
-                                 {"url", value.url()}});
+        matjson::Value ret = matjson::makeObject({{"name", value.metadata()->name},
+                                                  {"unique_id", value.metadata()->uniqueID},
+                                                  {"artist", value.metadata()->artist},
+                                                  {"path", value.path().value()},
+                                                  {"filename", value.path()->filename()},
+                                                  {"offset", value.metadata()->startOffset},
+                                                  {"url", value.url()}});
         if (value.indexID().has_value()) {
             ret["index_id"] = value.indexID().value();
         }
@@ -192,8 +177,7 @@ struct matjson::Serialize<jukebox::Nongs> {
     static matjson::Value toJson(jukebox::Nongs& value) {
         matjson::Value ret = matjson::makeObject({});
 
-        ret["default"] = matjson::Serialize<jukebox::LocalSong>::toJson(
-            *value.defaultSong());
+        ret["default"] = matjson::Serialize<jukebox::LocalSong>::toJson(*value.defaultSong());
 
         ret["active"] = value.active()->metadata()->uniqueID;
 
@@ -210,8 +194,7 @@ struct matjson::Serialize<jukebox::Nongs> {
             if (!youtube->path().has_value()) {
                 continue;
             }
-            youtubes.push(
-                matjson::Serialize<jukebox::YTSong>::toJson(*youtube));
+            youtubes.push(matjson::Serialize<jukebox::YTSong>::toJson(*youtube));
         }
         ret["youtube"] = youtubes;
 
@@ -220,89 +203,72 @@ struct matjson::Serialize<jukebox::Nongs> {
             if (!hosted->path().has_value()) {
                 continue;
             }
-            hosteds.push(
-                matjson::Serialize<jukebox::HostedSong>::toJson(*hosted));
+            hosteds.push(matjson::Serialize<jukebox::HostedSong>::toJson(*hosted));
         }
         ret["hosted"] = hosteds;
 
         return ret;
     }
 
-    static geode::Result<jukebox::Nongs> fromJson(const matjson::Value& value,
-                                                  int songID) {
+    static geode::Result<jukebox::Nongs> fromJson(const matjson::Value& value, int songID) {
         if (!value["default"].isObject()) {
             return geode::Err("Invalid nongs object for id {}", songID);
         }
 
         GEODE_UNWRAP_INTO(jukebox::LocalSong defaultSong,
-                          matjson::Serialize<jukebox::LocalSong>::fromJson(
-                              value["default"], songID)
+                          matjson::Serialize<jukebox::LocalSong>::fromJson(value["default"], songID)
                               .mapErr([songID](std::string err) {
-                                  return fmt::format(
-                                      "Failed to parse default song for ID {}",
-                                      songID);
+                                  return fmt::format("Failed to parse default song for ID {}", songID);
                               }));
 
         jukebox::Nongs nongs = {songID, std::move(defaultSong)};
 
         if (value["locals"].isArray()) {
             for (const matjson::Value& local : value["locals"]) {
-                geode::Result<jukebox::LocalSong> res =
-                    matjson::Serialize<jukebox::LocalSong>::fromJson(local,
-                                                                     songID);
+                geode::Result<jukebox::LocalSong> res = matjson::Serialize<jukebox::LocalSong>::fromJson(local, songID);
 
                 if (res.isErr()) {
-                    geode::log::error("Failed to load local song: {}",
-                                      res.unwrapErr());
+                    geode::log::error("Failed to load local song: {}", res.unwrapErr());
                     continue;
                 }
 
-                nongs.locals().push_back(
-                    std::make_unique<jukebox::LocalSong>(res.unwrap()));
+                nongs.locals().push_back(std::make_unique<jukebox::LocalSong>(res.unwrap()));
             }
         }
 
         if (value["youtube"].isArray()) {
             for (const matjson::Value& yt : value["youtube"]) {
-                geode::Result<jukebox::YTSong> res =
-                    matjson::Serialize<jukebox::YTSong>::fromJson(yt, songID);
+                geode::Result<jukebox::YTSong> res = matjson::Serialize<jukebox::YTSong>::fromJson(yt, songID);
 
                 if (res.isErr()) {
-                    geode::log::error("Failed to load YouTube song: {}",
-                                      res.unwrapErr());
+                    geode::log::error("Failed to load YouTube song: {}", res.unwrapErr());
                     continue;
                 }
 
-                nongs.youtube().push_back(
-                    std::make_unique<jukebox::YTSong>(res.unwrap()));
+                nongs.youtube().push_back(std::make_unique<jukebox::YTSong>(res.unwrap()));
             }
         }
 
         if (value["hosted"].isArray()) {
             for (auto& hosted : value["hosted"]) {
                 geode::Result<jukebox::HostedSong> res =
-                    matjson::Serialize<jukebox::HostedSong>::fromJson(hosted,
-                                                                      songID);
+                    matjson::Serialize<jukebox::HostedSong>::fromJson(hosted, songID);
 
                 if (res.isErr()) {
-                    geode::log::error("Failed to load hosted song: {}",
-                                      res.unwrapErr());
+                    geode::log::error("Failed to load hosted song: {}", res.unwrapErr());
                     continue;
                 }
 
-                nongs.hosted().push_back(
-                    std::make_unique<jukebox::HostedSong>(res.unwrap()));
+                nongs.hosted().push_back(std::make_unique<jukebox::HostedSong>(res.unwrap()));
             }
         }
 
         if (!value["active"].isString()) {
-            GEODE_UNWRAP(nongs.setActive(nongs.defaultSong()->metadata()->uniqueID)
-                             .mapErr([](std::string err) {
-                                 return fmt::format("Failed to set default active song while loading JSON: {}", err);
-                             }));
+            GEODE_UNWRAP(nongs.setActive(nongs.defaultSong()->metadata()->uniqueID).mapErr([](std::string err) {
+                return fmt::format("Failed to set default active song while loading JSON: {}", err);
+            }));
         } else {
-            geode::Result<> res =
-                nongs.setActive(value["active"].asString().unwrap());
+            geode::Result<> res = nongs.setActive(value["active"].asString().unwrap());
             if (res.isErr()) {
                 GEODE_UNWRAP(nongs.setActive(nongs.defaultSong()->metadata()->uniqueID)
                                  .mapErr([res = res.unwrapErr()](std::string fallbackErr) {


### PR DESCRIPTION
Instead of storing the whole path for songs in the manifest, only store the filename, since we know the base path from NongManager.

Makes it easier to port Jukebox data across systems.